### PR TITLE
this will make it list correctly on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository" : {
 	"type" : "git",
-	"url" : "https://gjtorikian@github.com/gjtorikian/markdown_conrefs_js.git"
+	"url" : "https://github.com/gjtorikian/markdown_conrefs_js.git"
 	},
   "dependencies": {
     "hash": ">=0.2.0",


### PR DESCRIPTION
Taking out the user makes it link and work correctly on it's [npm listing](https://www.npmjs.org/package/markdown_conrefs).
